### PR TITLE
AG-11722 improve and fix commandline parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+.DS_Store
 /node_modules/
 /packages/*/node_modules/
 /packages/*/vitest.config.mts.timestamp-*.mjs
 /coverage/
 /docs/
+**/_temp/**/*

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -170,7 +170,6 @@ export function parseArgs(args: string[], env: CliEnv): MigrateCommandArgs {
           throw new CliArgsError(`Missing value for ${arg}`, usage(env));
         }
         value = semverCoerce(value);
-        console.log(value);
         if (!semver.valid(value)) {
           throw new CliArgsError(
             `Invalid ${arg} migration starting version`,

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -181,9 +181,14 @@ export function parseArgs(args: string[], env: CliEnv): MigrateCommandArgs {
         break;
       }
       case '--to': {
-        const value = args.shift();
+        let value = args.shift();
         if (!value || value.startsWith('-')) {
           throw new CliArgsError(`Missing value for ${arg}`, usage(env));
+        }
+        if (value === 'latest') {
+          value = LATEST_VERSION;
+        } else {
+          value = semverCoerce(value);
         }
         if (!versions.some(({ version }) => version === value)) {
           throw new CliArgsError(

--- a/packages/cli/src/utils/fs.ts
+++ b/packages/cli/src/utils/fs.ts
@@ -33,6 +33,7 @@ export async function findGitRoot(path: string): Promise<string | undefined> {
 export async function findSourceFiles(
   path: string,
   extensions: string[],
+  skipFiles: string[],
   gitRoot: string | undefined,
 ): Promise<Array<string>> {
   path = resolve(path);
@@ -47,6 +48,11 @@ export async function findSourceFiles(
       ignore: ['**/node_modules/**', '**/.git/**'],
     },
   );
+
+  if (skipFiles.length > 0) {
+    const skipFilesSet = new Set(skipFiles);
+    files = files.filter((file) => !skipFilesSet.has(file));
+  }
 
   interface DirGitignore {
     directory: string;


### PR DESCRIPTION
Fix command line parsing

- The "--config=file" should not be included in the files to be processed
- Partial semvers should be supported, "from=30" should work the same as "from=30.0.0"
- All boolean flags should have an implicit "--no-flag" so they can be overridden when chaining commangs (normal cli behaviour)
- --to= should support "latest" and partial semver, for example --to=32.1 or --to=latest