### PR TITLE
AG-12276 support vue ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/types": "7.23.0",
     "@types/glob": "8.1.0",
     "glob": "11.0.0",
-    "prettier": "3.3.2",
+    "prettier": "3.3.3",
     "typedoc": "^0.26.3",
     "typescript": "5.5.3",
     "tsx": "4.16.2",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -57,7 +57,7 @@
     "@ag-grid-devtools/build-config": "workspace:*"
   },
   "peerDependencies": {
-    "eslint": "^8",
+    "eslint": "8.57.0",
     "typedoc": "^0.26",
     "typescript": "^5",
     "vite": "^5",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -59,7 +59,7 @@
   "peerDependencies": {
     "eslint": "8.57.0",
     "typedoc": "^0.26",
-    "typescript": "^5",
+    "typescript": "5.5.3",
     "vite": "^5",
     "vitest": "^1"
   }

--- a/packages/build-config/package.json
+++ b/packages/build-config/package.json
@@ -23,7 +23,7 @@
     "@typescript-eslint/parser": "7.16.1",
     "@vitejs/plugin-react-swc": "3.7.0",
     "@vitest/coverage-v8": "1.6.0",
-    "eslint": "8.56.0",
+    "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.1.3",
     "eslint-plugin-react-hooks": "4.6.2",

--- a/packages/build-config/package.json
+++ b/packages/build-config/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "@types/node": "20.14.10",
     "@types/react": "18.3.3",
-    "@typescript-eslint/eslint-plugin": "7.14.1",
-    "@typescript-eslint/parser": "7.14.1",
+    "@typescript-eslint/eslint-plugin": "7.16.1",
+    "@typescript-eslint/parser": "7.16.1",
     "@vitejs/plugin-react-swc": "3.7.0",
     "@vitest/coverage-v8": "1.6.0",
     "eslint": "8.56.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -86,7 +86,7 @@
     "vite-plugin-static-copy": "1.0.6"
   },
   "peerDependencies": {
-    "eslint": "^8",
+    "eslint": "8.57.0",
     "typedoc": "^0.26",
     "typescript": "^5",
     "vite": "^5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,6 +65,8 @@
   ],
   "dependencies": {
     "@ag-grid-devtools/codemods": "workspace:*",
+    "@typescript-eslint/parser": "7.16.1",
+    "eslint": "8.57.0",
     "tsx": "4.16.2"
   },
   "devDependencies": {
@@ -88,7 +90,7 @@
   "peerDependencies": {
     "eslint": "8.57.0",
     "typedoc": "^0.26",
-    "typescript": "^5",
+    "typescript": "5.5.3",
     "vite": "^5",
     "vitest": "^1"
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,8 @@
       },
       "./user-config.js": "./user-config.mjs",
       "./user-config.mjs": "./user-config.mjs",
-      "./user-config.cjs": "./user-config.cjs"
+      "./user-config.cjs": "./user-config.cjs",
+      "./package.json": "./package.json"
     }
   },
   "types": "./index.d.ts",

--- a/packages/codemod-task-utils/package.json
+++ b/packages/codemod-task-utils/package.json
@@ -49,7 +49,7 @@
     "@ag-grid-devtools/build-config": "workspace:*"
   },
   "peerDependencies": {
-    "eslint": "^8",
+    "eslint": "8.57.0",
     "typedoc": "^0.26",
     "typescript": "^5",
     "vite": "^5",

--- a/packages/codemod-task-utils/package.json
+++ b/packages/codemod-task-utils/package.json
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "eslint": "8.57.0",
     "typedoc": "^0.26",
-    "typescript": "^5",
+    "typescript": "5.5.3",
     "vite": "^5",
     "vitest": "^1"
   }

--- a/packages/codemod-utils/package.json
+++ b/packages/codemod-utils/package.json
@@ -46,9 +46,11 @@
     "@ag-grid-devtools/utils": "workspace:*",
     "@angular-eslint/template-parser": "17.5.2",
     "@angular/compiler": "17.0.1",
-    "@typescript-eslint/types": "7.14.1",
-    "prettier": "3.3.2",
+    "@typescript-eslint/types": "7.16.1",
+    "@typescript-eslint/parser": "7.16.1",
+    "prettier": "3.3.3",
     "recast": "0.23.4",
+    "typescript": "5.5.3",
     "vue-eslint-parser": "9.3.2"
   },
   "devDependencies": {
@@ -56,7 +58,7 @@
     "@ag-grid-devtools/test-utils": "workspace:*"
   },
   "peerDependencies": {
-    "eslint": "^8",
+    "eslint": "8.57.0",
     "typedoc": "^0.26",
     "typescript": "^5",
     "vite": "^5",

--- a/packages/codemod-utils/package.json
+++ b/packages/codemod-utils/package.json
@@ -47,10 +47,8 @@
     "@angular-eslint/template-parser": "17.5.2",
     "@angular/compiler": "17.0.1",
     "@typescript-eslint/types": "7.16.1",
-    "@typescript-eslint/parser": "7.16.1",
     "prettier": "3.3.3",
     "recast": "0.23.4",
-    "typescript": "5.5.3",
     "vue-eslint-parser": "9.3.2"
   },
   "devDependencies": {
@@ -58,9 +56,10 @@
     "@ag-grid-devtools/test-utils": "workspace:*"
   },
   "peerDependencies": {
+    "@typescript-eslint/parser": "7.16.1",
     "eslint": "8.57.0",
     "typedoc": "^0.26",
-    "typescript": "^5",
+    "typescript": "5.5.3",
     "vite": "^5",
     "vitest": "^1"
   }

--- a/packages/codemod-utils/src/vueHelpers.ts
+++ b/packages/codemod-utils/src/vueHelpers.ts
@@ -400,6 +400,9 @@ export function matchVueComponentMethod(method: NodePath): {
 export function parseVueSfcComponent(source: string): AST.ESLintProgram {
   return parse(source, {
     sourceType: 'module',
+    parser: {
+      ts: '@typescript-eslint/parser',
+    },
   });
 }
 

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -71,7 +71,7 @@
   "peerDependencies": {
     "eslint": "8.57.0",
     "typedoc": "^0.26",
-    "typescript": "^5",
+    "typescript": "5.5.3",
     "vite": "^5",
     "vitest": "^1"
   }

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -69,7 +69,7 @@
     "@ag-grid-devtools/utils": "workspace:*"
   },
   "peerDependencies": {
-    "eslint": "^8",
+    "eslint": "8.57.0",
     "typedoc": "^0.26",
     "typescript": "^5",
     "vite": "^5",

--- a/packages/codemods/src/transforms/migrate-legacy-column-api-v31/__fixtures__/scenarios/vue/sfc/component-field-event-property-accessor/input.vue
+++ b/packages/codemods/src/transforms/migrate-legacy-column-api-v31/__fixtures__/scenarios/vue/sfc/component-field-event-property-accessor/input.vue
@@ -9,8 +9,10 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { AgGridVue } from '@ag-grid-community/vue';
+
+export interface MyInterfaceToTestTsParser {}
 
 export default {
   components: {

--- a/packages/codemods/src/transforms/migrate-legacy-column-api-v31/__fixtures__/scenarios/vue/sfc/component-field-event-property-accessor/output.vue
+++ b/packages/codemods/src/transforms/migrate-legacy-column-api-v31/__fixtures__/scenarios/vue/sfc/component-field-event-property-accessor/output.vue
@@ -9,8 +9,10 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { AgGridVue } from '@ag-grid-community/vue';
+
+export interface MyInterfaceToTestTsParser {}
 
 export default {
   components: {

--- a/packages/systemjs-plugin/package.json
+++ b/packages/systemjs-plugin/package.json
@@ -39,8 +39,8 @@
     "@babel/plugin-transform-react-jsx": "^7.23.4",
     "@babel/plugin-transform-typescript": "^7.23.6",
     "@types/babel__core": "^7.20.5",
-    "@typescript-eslint/eslint-plugin": "7.14.1",
-    "@typescript-eslint/parser": "7.14.1"
+    "@typescript-eslint/eslint-plugin": "7.16.1",
+    "@typescript-eslint/parser": "7.16.1"
   },
   "peerDependencies": {
     "eslint": "^8.56.0",

--- a/packages/systemjs-plugin/package.json
+++ b/packages/systemjs-plugin/package.json
@@ -43,7 +43,7 @@
     "@typescript-eslint/parser": "7.16.1"
   },
   "peerDependencies": {
-    "eslint": "^8.56.0",
+    "eslint": "8.57.0",
     "typescript": "^5.5.3",
     "vite": "^5",
     "vite-plugin-node-polyfills": "^0.22"

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -56,7 +56,7 @@
     "@vitest/runner": "^1",
     "eslint": "8.57.0",
     "typedoc": "^0.26",
-    "typescript": "^5",
+    "typescript": "5.5.3",
     "vite": "^5",
     "vitest": "^1"
   }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -45,7 +45,7 @@
     "@ag-grid-devtools/utils": "workspace:*",
     "@angular-eslint/template-parser": "17.5.2",
     "@angular/compiler": "17.0.1",
-    "@typescript-eslint/types": "7.14.1",
+    "@typescript-eslint/types": "7.16.1",
     "memfs": "4.6.0"
   },
   "devDependencies": {
@@ -54,7 +54,7 @@
   "peerDependencies": {
     "@vitest/expect": "^1",
     "@vitest/runner": "^1",
-    "eslint": "^8",
+    "eslint": "8.57.0",
     "typedoc": "^0.26",
     "typescript": "^5",
     "vite": "^5",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -41,7 +41,7 @@
     "@ag-grid-devtools/build-config": "workspace:*"
   },
   "peerDependencies": {
-    "eslint": "^8",
+    "eslint": "8.57.0",
     "typedoc": "^0.26",
     "typescript": "^5",
     "vite": "^5"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "eslint": "8.57.0",
     "typedoc": "^0.26",
-    "typescript": "^5",
+    "typescript": "5.5.3",
     "vite": "^5"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -48,7 +48,7 @@
     "app-module-path": "2.2.0"
   },
   "peerDependencies": {
-    "eslint": "^8",
+    "eslint": "8.57.0",
     "typedoc": "^0.26",
     "typescript": "^5",
     "vite": "^5",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "eslint": "8.57.0",
     "typedoc": "^0.26",
-    "typescript": "^5",
+    "typescript": "5.5.3",
     "vite": "^5",
     "vitest": "^1"
   }

--- a/packages/worker-utils/package.json
+++ b/packages/worker-utils/package.json
@@ -46,7 +46,7 @@
     "@ag-grid-devtools/build-config": "workspace:*"
   },
   "peerDependencies": {
-    "eslint": "^8",
+    "eslint": "8.57.0",
     "typedoc": "^0.26",
     "typescript": "^5",
     "vite": "^5",

--- a/packages/worker-utils/package.json
+++ b/packages/worker-utils/package.json
@@ -48,7 +48,7 @@
   "peerDependencies": {
     "eslint": "8.57.0",
     "typedoc": "^0.26",
-    "typescript": "^5",
+    "typescript": "5.5.3",
     "vite": "^5",
     "vitest": "^1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,10 +97,10 @@ importers:
         version: 8.57.0
       typedoc:
         specifier: ^0.26
-        version: 0.26.3(typescript@5.2.2)
+        version: 0.26.3(typescript@5.5.3)
       typescript:
-        specifier: ^5
-        version: 5.2.2
+        specifier: 5.5.3
+        version: 5.5.3
       vite:
         specifier: ^5
         version: 5.0.11(@types/node@20.14.10)
@@ -122,10 +122,10 @@ importers:
         version: 18.3.3
       '@typescript-eslint/eslint-plugin':
         specifier: 7.16.1
-        version: 7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)
+        version: 7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)
       '@typescript-eslint/parser':
         specifier: 7.16.1
-        version: 7.16.1(eslint@8.56.0)(typescript@5.5.3)
+        version: 7.16.1(eslint@8.57.0)(typescript@5.5.3)
       '@vitejs/plugin-react-swc':
         specifier: 3.7.0
         version: 3.7.0(vite@5.3.3(@types/node@20.14.10))
@@ -133,20 +133,20 @@ importers:
         specifier: 1.6.0
         version: 1.6.0(vitest@1.6.0(@types/node@20.14.10))
       eslint:
-        specifier: 8.56.0
-        version: 8.56.0
+        specifier: 8.57.0
+        version: 8.57.0
       eslint-config-prettier:
         specifier: 9.1.0
-        version: 9.1.0(eslint@8.56.0)
+        version: 9.1.0(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 5.1.3
-        version: 5.1.3(eslint-config-prettier@9.1.0(eslint@8.56.0))(eslint@8.56.0)(prettier@3.3.2)
+        version: 5.1.3(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.2)
       eslint-plugin-react-hooks:
         specifier: 4.6.2
-        version: 4.6.2(eslint@8.56.0)
+        version: 4.6.2(eslint@8.57.0)
       eslint-plugin-vitest:
         specifier: 0.4.1
-        version: 0.4.1(@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)(vitest@1.6.0(@types/node@20.14.10))
+        version: 0.4.1(@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)(vitest@1.6.0(@types/node@20.14.10))
       prettier:
         specifier: 3.3.2
         version: 3.3.2
@@ -183,6 +183,9 @@ importers:
       '@ag-grid-devtools/codemods':
         specifier: workspace:*
         version: link:../codemods
+      '@typescript-eslint/parser':
+        specifier: 7.16.1
+        version: 7.16.1(eslint@8.57.0)(typescript@5.5.3)
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -191,10 +194,10 @@ importers:
         version: 4.16.2
       typedoc:
         specifier: ^0.26
-        version: 0.26.3(typescript@5.2.2)
+        version: 0.26.3(typescript@5.5.3)
       typescript:
-        specifier: ^5
-        version: 5.2.2
+        specifier: 5.5.3
+        version: 5.5.3
       vite:
         specifier: ^5
         version: 5.0.11(@types/node@20.14.10)
@@ -246,7 +249,7 @@ importers:
         version: 7.6.2
       vite-plugin-dts:
         specifier: 3.9.1
-        version: 3.9.1(@types/node@20.14.10)(rollup@4.18.0)(typescript@5.2.2)(vite@5.0.11(@types/node@20.14.10))
+        version: 3.9.1(@types/node@20.14.10)(rollup@4.18.0)(typescript@5.5.3)(vite@5.0.11(@types/node@20.14.10))
       vite-plugin-static-copy:
         specifier: 1.0.6
         version: 1.0.6(vite@5.0.11(@types/node@20.14.10))
@@ -267,10 +270,10 @@ importers:
         version: 8.57.0
       typedoc:
         specifier: ^0.26
-        version: 0.26.3(typescript@5.2.2)
+        version: 0.26.3(typescript@5.5.3)
       typescript:
-        specifier: ^5
-        version: 5.2.2
+        specifier: 5.5.3
+        version: 5.5.3
       vite:
         specifier: ^5
         version: 5.0.11(@types/node@20.14.10)
@@ -344,10 +347,10 @@ importers:
         version: 8.57.0
       typedoc:
         specifier: ^0.26
-        version: 0.26.3(typescript@5.2.2)
+        version: 0.26.3(typescript@5.5.3)
       typescript:
-        specifier: ^5
-        version: 5.2.2
+        specifier: 5.5.3
+        version: 5.5.3
       vite:
         specifier: ^5
         version: 5.0.11(@types/node@20.14.10)
@@ -383,8 +386,8 @@ importers:
   packages/systemjs-plugin:
     dependencies:
       eslint:
-        specifier: ^8.56.0
-        version: 8.56.0
+        specifier: 8.57.0
+        version: 8.57.0
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -430,10 +433,10 @@ importers:
         version: 7.20.5
       '@typescript-eslint/eslint-plugin':
         specifier: 7.16.1
-        version: 7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)
+        version: 7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)
       '@typescript-eslint/parser':
         specifier: 7.16.1
-        version: 7.16.1(eslint@8.56.0)(typescript@5.5.3)
+        version: 7.16.1(eslint@8.57.0)(typescript@5.5.3)
 
   packages/test-utils:
     dependencies:
@@ -448,7 +451,7 @@ importers:
         version: link:../utils
       '@angular-eslint/template-parser':
         specifier: 17.5.2
-        version: 17.5.2(eslint@8.57.0)(typescript@5.2.2)
+        version: 17.5.2(eslint@8.57.0)(typescript@5.5.3)
       '@angular/compiler':
         specifier: 17.0.1
         version: 17.0.1
@@ -469,10 +472,10 @@ importers:
         version: 4.6.0(quill-delta@5.1.0)(rxjs@7.8.1)(tslib@2.6.2)
       typedoc:
         specifier: ^0.26
-        version: 0.26.3(typescript@5.2.2)
+        version: 0.26.3(typescript@5.5.3)
       typescript:
-        specifier: ^5
-        version: 5.2.2
+        specifier: 5.5.3
+        version: 5.5.3
       vite:
         specifier: ^5
         version: 5.0.11(@types/node@20.14.10)
@@ -491,10 +494,10 @@ importers:
         version: 8.57.0
       typedoc:
         specifier: ^0.26
-        version: 0.26.3(typescript@5.2.2)
+        version: 0.26.3(typescript@5.5.3)
       typescript:
-        specifier: ^5
-        version: 5.2.2
+        specifier: 5.5.3
+        version: 5.5.3
       vite:
         specifier: ^5
         version: 5.0.11(@types/node@20.14.10)
@@ -513,10 +516,10 @@ importers:
         version: 8.57.0
       typedoc:
         specifier: ^0.26
-        version: 0.26.3(typescript@5.2.2)
+        version: 0.26.3(typescript@5.5.3)
       typescript:
-        specifier: ^5
-        version: 5.2.2
+        specifier: 5.5.3
+        version: 5.5.3
       vite:
         specifier: ^5
         version: 5.0.11(@types/node@20.14.10)
@@ -553,10 +556,10 @@ importers:
         version: 4.2.11
       typedoc:
         specifier: ^0.26
-        version: 0.26.3(typescript@5.2.2)
+        version: 0.26.3(typescript@5.5.3)
       typescript:
-        specifier: ^5
-        version: 5.2.2
+        specifier: 5.5.3
+        version: 5.5.3
       vite:
         specifier: ^5
         version: 5.0.11(@types/node@20.14.10)
@@ -1110,10 +1113,6 @@ packages:
 
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  '@eslint/js@8.56.0':
-    resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@eslint/js@8.57.0':
@@ -2048,11 +2047,6 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  eslint@8.56.0:
-    resolution: {integrity: sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    hasBin: true
-
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2813,6 +2807,7 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   ripemd160@2.0.2:
@@ -3053,11 +3048,6 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x
-
-  typescript@5.2.2:
-    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   typescript@5.4.2:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
@@ -3326,13 +3316,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.19
 
   '@angular-eslint/bundled-angular-compiler@17.5.2': {}
-
-  '@angular-eslint/template-parser@17.5.2(eslint@8.57.0)(typescript@5.2.2)':
-    dependencies:
-      '@angular-eslint/bundled-angular-compiler': 17.5.2
-      eslint: 8.57.0
-      eslint-scope: 8.0.1
-      typescript: 5.2.2
 
   '@angular-eslint/template-parser@17.5.2(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
@@ -3793,11 +3776,6 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@8.56.0)':
-    dependencies:
-      eslint: 8.56.0
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
     dependencies:
       eslint: 8.57.0
@@ -3818,8 +3796,6 @@ snapshots:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-
-  '@eslint/js@8.56.0': {}
 
   '@eslint/js@8.57.0': {}
 
@@ -4178,32 +4154,19 @@ snapshots:
 
   '@types/semver@7.5.8': {}
 
-  '@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)':
+  '@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 7.16.1(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/parser': 7.16.1(eslint@8.57.0)(typescript@5.5.3)
       '@typescript-eslint/scope-manager': 7.16.1
-      '@typescript-eslint/type-utils': 7.16.1(eslint@8.56.0)(typescript@5.5.3)
-      '@typescript-eslint/utils': 7.16.1(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/type-utils': 7.16.1(eslint@8.57.0)(typescript@5.5.3)
+      '@typescript-eslint/utils': 7.16.1(eslint@8.57.0)(typescript@5.5.3)
       '@typescript-eslint/visitor-keys': 7.16.1
-      eslint: 8.56.0
+      eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
       ts-api-utils: 1.3.0(typescript@5.5.3)
-    optionalDependencies:
-      typescript: 5.5.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@7.16.1(eslint@8.56.0)(typescript@5.5.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 7.16.1
-      '@typescript-eslint/types': 7.16.1
-      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.5.3)
-      '@typescript-eslint/visitor-keys': 7.16.1
-      debug: 4.3.4
-      eslint: 8.56.0
     optionalDependencies:
       typescript: 5.5.3
     transitivePeerDependencies:
@@ -4232,12 +4195,12 @@ snapshots:
       '@typescript-eslint/types': 7.16.1
       '@typescript-eslint/visitor-keys': 7.16.1
 
-  '@typescript-eslint/type-utils@7.16.1(eslint@8.56.0)(typescript@5.5.3)':
+  '@typescript-eslint/type-utils@7.16.1(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.5.3)
-      '@typescript-eslint/utils': 7.16.1(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/utils': 7.16.1(eslint@8.57.0)(typescript@5.5.3)
       debug: 4.3.4
-      eslint: 8.56.0
+      eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.5.3)
     optionalDependencies:
       typescript: 5.5.3
@@ -4278,24 +4241,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.14.1(eslint@8.56.0)(typescript@5.5.3)':
+  '@typescript-eslint/utils@7.14.1(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@typescript-eslint/scope-manager': 7.14.1
       '@typescript-eslint/types': 7.14.1
       '@typescript-eslint/typescript-estree': 7.14.1(typescript@5.5.3)
-      eslint: 8.56.0
+      eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.16.1(eslint@8.56.0)(typescript@5.5.3)':
+  '@typescript-eslint/utils@7.16.1(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@typescript-eslint/scope-manager': 7.16.1
       '@typescript-eslint/types': 7.16.1
       '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.5.3)
-      eslint: 8.56.0
+      eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -4420,20 +4383,6 @@ snapshots:
     dependencies:
       '@vue/compiler-core': 3.3.4
       '@vue/shared': 3.3.4
-
-  '@vue/language-core@1.8.27(typescript@5.2.2)':
-    dependencies:
-      '@volar/language-core': 1.11.1
-      '@volar/source-map': 1.11.1
-      '@vue/compiler-dom': 3.3.4
-      '@vue/shared': 3.3.4
-      computeds: 0.0.1
-      minimatch: 9.0.5
-      muggle-string: 0.3.1
-      path-browserify: 1.0.1
-      vue-template-compiler: 2.7.14
-    optionalDependencies:
-      typescript: 5.2.2
 
   '@vue/language-core@1.8.27(typescript@5.5.3)':
     dependencies:
@@ -4862,29 +4811,29 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@9.1.0(eslint@8.56.0):
+  eslint-config-prettier@9.1.0(eslint@8.57.0):
     dependencies:
-      eslint: 8.56.0
+      eslint: 8.57.0
 
-  eslint-plugin-prettier@5.1.3(eslint-config-prettier@9.1.0(eslint@8.56.0))(eslint@8.56.0)(prettier@3.3.2):
+  eslint-plugin-prettier@5.1.3(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.2):
     dependencies:
-      eslint: 8.56.0
+      eslint: 8.57.0
       prettier: 3.3.2
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.8
     optionalDependencies:
-      eslint-config-prettier: 9.1.0(eslint@8.56.0)
+      eslint-config-prettier: 9.1.0(eslint@8.57.0)
 
-  eslint-plugin-react-hooks@4.6.2(eslint@8.56.0):
+  eslint-plugin-react-hooks@4.6.2(eslint@8.57.0):
     dependencies:
-      eslint: 8.56.0
+      eslint: 8.57.0
 
-  eslint-plugin-vitest@0.4.1(@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)(vitest@1.6.0(@types/node@20.14.10)):
+  eslint-plugin-vitest@0.4.1(@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)(vitest@1.6.0(@types/node@20.14.10)):
     dependencies:
-      '@typescript-eslint/utils': 7.14.1(eslint@8.56.0)(typescript@5.5.3)
-      eslint: 8.56.0
+      '@typescript-eslint/utils': 7.14.1(eslint@8.57.0)(typescript@5.5.3)
+      eslint: 8.57.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/eslint-plugin': 7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)
       vitest: 1.6.0(@types/node@20.14.10)
     transitivePeerDependencies:
       - supports-color
@@ -4901,49 +4850,6 @@ snapshots:
       estraverse: 5.3.0
 
   eslint-visitor-keys@3.4.3: {}
-
-  eslint@8.56.0:
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
-      '@eslint-community/regexpp': 4.11.0
-      '@eslint/eslintrc': 2.1.4
-      '@eslint/js': 8.56.0
-      '@humanwhocodes/config-array': 0.11.14
-      '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      '@ungap/structured-clone': 1.2.0
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
-      esquery: 1.5.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.21.0
-      graphemer: 1.4.0
-      ignore: 5.3.1
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.3
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
 
   eslint@8.57.0:
     dependencies:
@@ -6004,15 +5910,6 @@ snapshots:
 
   type-fest@0.20.2: {}
 
-  typedoc@0.26.3(typescript@5.2.2):
-    dependencies:
-      lunr: 2.3.9
-      markdown-it: 14.1.0
-      minimatch: 9.0.5
-      shiki: 1.9.1
-      typescript: 5.2.2
-      yaml: 2.4.5
-
   typedoc@0.26.3(typescript@5.5.3):
     dependencies:
       lunr: 2.3.9
@@ -6021,8 +5918,6 @@ snapshots:
       shiki: 1.9.1
       typescript: 5.5.3
       yaml: 2.4.5
-
-  typescript@5.2.2: {}
 
   typescript@5.4.2: {}
 
@@ -6099,16 +5994,16 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-dts@3.9.1(@types/node@20.14.10)(rollup@4.18.0)(typescript@5.2.2)(vite@5.0.11(@types/node@20.14.10)):
+  vite-plugin-dts@3.9.1(@types/node@20.14.10)(rollup@4.18.0)(typescript@5.5.3)(vite@5.0.11(@types/node@20.14.10)):
     dependencies:
       '@microsoft/api-extractor': 7.43.0(@types/node@20.14.10)
       '@rollup/pluginutils': 5.1.0(rollup@4.18.0)
-      '@vue/language-core': 1.8.27(typescript@5.2.2)
+      '@vue/language-core': 1.8.27(typescript@5.5.3)
       debug: 4.3.4
       kolorist: 1.8.0
       magic-string: 0.30.10
-      typescript: 5.2.2
-      vue-tsc: 1.8.27(typescript@5.2.2)
+      typescript: 5.5.3
+      vue-tsc: 1.8.27(typescript@5.5.3)
     optionalDependencies:
       vite: 5.0.11(@types/node@20.14.10)
     transitivePeerDependencies:
@@ -6268,13 +6163,6 @@ snapshots:
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
-
-  vue-tsc@1.8.27(typescript@5.2.2):
-    dependencies:
-      '@volar/typescript': 1.11.1
-      '@vue/language-core': 1.8.27(typescript@5.2.2)
-      semver: 7.6.2
-      typescript: 5.2.2
 
   vue-tsc@1.8.27(typescript@5.5.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: 11.0.0
         version: 11.0.0
       prettier:
-        specifier: 3.3.2
-        version: 3.3.2
+        specifier: 3.3.3
+        version: 3.3.3
       tsx:
         specifier: 4.16.2
         version: 4.16.2
@@ -93,8 +93,8 @@ importers:
         specifier: 7.20.3
         version: 7.20.3
       eslint:
-        specifier: ^8
-        version: 8.48.0
+        specifier: 8.57.0
+        version: 8.57.0
       typedoc:
         specifier: ^0.26
         version: 0.26.3(typescript@5.2.2)
@@ -121,11 +121,11 @@ importers:
         specifier: 18.3.3
         version: 18.3.3
       '@typescript-eslint/eslint-plugin':
-        specifier: 7.14.1
-        version: 7.14.1(@typescript-eslint/parser@7.14.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)
+        specifier: 7.16.1
+        version: 7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)
       '@typescript-eslint/parser':
-        specifier: 7.14.1
-        version: 7.14.1(eslint@8.56.0)(typescript@5.5.3)
+        specifier: 7.16.1
+        version: 7.16.1(eslint@8.56.0)(typescript@5.5.3)
       '@vitejs/plugin-react-swc':
         specifier: 3.7.0
         version: 3.7.0(vite@5.3.3(@types/node@20.14.10))
@@ -146,7 +146,7 @@ importers:
         version: 4.6.2(eslint@8.56.0)
       eslint-plugin-vitest:
         specifier: 0.4.1
-        version: 0.4.1(@typescript-eslint/eslint-plugin@7.14.1(@typescript-eslint/parser@7.14.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)(vitest@1.6.0(@types/node@20.14.10))
+        version: 0.4.1(@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)(vitest@1.6.0(@types/node@20.14.10))
       prettier:
         specifier: 3.3.2
         version: 3.3.2
@@ -184,8 +184,8 @@ importers:
         specifier: workspace:*
         version: link:../codemods
       eslint:
-        specifier: ^8
-        version: 8.48.0
+        specifier: 8.57.0
+        version: 8.57.0
       tsx:
         specifier: 4.16.2
         version: 4.16.2
@@ -263,8 +263,8 @@ importers:
         specifier: workspace:*
         version: link:../worker-utils
       eslint:
-        specifier: ^8
-        version: 8.48.0
+        specifier: 8.57.0
+        version: 8.57.0
       typedoc:
         specifier: ^0.26
         version: 0.26.3(typescript@5.2.2)
@@ -295,28 +295,31 @@ importers:
         version: link:../utils
       '@angular-eslint/template-parser':
         specifier: 17.5.2
-        version: 17.5.2(eslint@8.48.0)(typescript@5.2.2)
+        version: 17.5.2(eslint@8.57.0)(typescript@5.5.3)
       '@angular/compiler':
         specifier: 17.0.1
         version: 17.0.1
+      '@typescript-eslint/parser':
+        specifier: 7.16.1
+        version: 7.16.1(eslint@8.57.0)(typescript@5.5.3)
       '@typescript-eslint/types':
-        specifier: 7.14.1
-        version: 7.14.1
+        specifier: 7.16.1
+        version: 7.16.1
       eslint:
-        specifier: ^8
-        version: 8.48.0
+        specifier: 8.57.0
+        version: 8.57.0
       prettier:
-        specifier: 3.3.2
-        version: 3.3.2
+        specifier: 3.3.3
+        version: 3.3.3
       recast:
         specifier: 0.23.4
         version: 0.23.4
       typedoc:
         specifier: ^0.26
-        version: 0.26.3(typescript@5.2.2)
+        version: 0.26.3(typescript@5.5.3)
       typescript:
-        specifier: ^5
-        version: 5.2.2
+        specifier: 5.5.3
+        version: 5.5.3
       vite:
         specifier: ^5
         version: 5.0.11(@types/node@20.14.10)
@@ -325,7 +328,7 @@ importers:
         version: 1.3.1(@types/node@20.14.10)
       vue-eslint-parser:
         specifier: 9.3.2
-        version: 9.3.2(eslint@8.48.0)
+        version: 9.3.2(eslint@8.57.0)
     devDependencies:
       '@ag-grid-devtools/build-config':
         specifier: workspace:*
@@ -337,8 +340,8 @@ importers:
   packages/codemods:
     dependencies:
       eslint:
-        specifier: ^8
-        version: 8.48.0
+        specifier: 8.57.0
+        version: 8.57.0
       typedoc:
         specifier: ^0.26
         version: 0.26.3(typescript@5.2.2)
@@ -426,11 +429,11 @@ importers:
         specifier: ^7.20.5
         version: 7.20.5
       '@typescript-eslint/eslint-plugin':
-        specifier: 7.14.1
-        version: 7.14.1(@typescript-eslint/parser@7.14.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)
+        specifier: 7.16.1
+        version: 7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)
       '@typescript-eslint/parser':
-        specifier: 7.14.1
-        version: 7.14.1(eslint@8.56.0)(typescript@5.5.3)
+        specifier: 7.16.1
+        version: 7.16.1(eslint@8.56.0)(typescript@5.5.3)
 
   packages/test-utils:
     dependencies:
@@ -445,13 +448,13 @@ importers:
         version: link:../utils
       '@angular-eslint/template-parser':
         specifier: 17.5.2
-        version: 17.5.2(eslint@8.48.0)(typescript@5.2.2)
+        version: 17.5.2(eslint@8.57.0)(typescript@5.2.2)
       '@angular/compiler':
         specifier: 17.0.1
         version: 17.0.1
       '@typescript-eslint/types':
-        specifier: 7.14.1
-        version: 7.14.1
+        specifier: 7.16.1
+        version: 7.16.1
       '@vitest/expect':
         specifier: ^1
         version: 1.3.1
@@ -459,8 +462,8 @@ importers:
         specifier: ^1
         version: 1.3.1
       eslint:
-        specifier: ^8
-        version: 8.48.0
+        specifier: 8.57.0
+        version: 8.57.0
       memfs:
         specifier: 4.6.0
         version: 4.6.0(quill-delta@5.1.0)(rxjs@7.8.1)(tslib@2.6.2)
@@ -484,8 +487,8 @@ importers:
   packages/types:
     dependencies:
       eslint:
-        specifier: ^8
-        version: 8.48.0
+        specifier: 8.57.0
+        version: 8.57.0
       typedoc:
         specifier: ^0.26
         version: 0.26.3(typescript@5.2.2)
@@ -506,8 +509,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       eslint:
-        specifier: ^8
-        version: 8.48.0
+        specifier: 8.57.0
+        version: 8.57.0
       typedoc:
         specifier: ^0.26
         version: 0.26.3(typescript@5.2.2)
@@ -543,8 +546,8 @@ importers:
         specifier: 4.1.9
         version: 4.1.9
       eslint:
-        specifier: ^8
-        version: 8.48.0
+        specifier: 8.57.0
+        version: 8.57.0
       graceful-fs:
         specifier: 4.2.11
         version: 4.2.11
@@ -1105,29 +1108,17 @@ packages:
     resolution: {integrity: sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint-community/regexpp@4.8.0':
-    resolution: {integrity: sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-
-  '@eslint/eslintrc@2.1.2':
-    resolution: {integrity: sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  '@eslint/js@8.48.0':
-    resolution: {integrity: sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@eslint/js@8.56.0':
     resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@humanwhocodes/config-array@0.11.11':
-    resolution: {integrity: sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==}
-    engines: {node: '>=10.10.0'}
+  '@eslint/js@8.57.0':
+    resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -1137,9 +1128,6 @@ packages:
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
-
-  '@humanwhocodes/object-schema@1.2.1':
-    resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
 
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
@@ -1528,8 +1516,8 @@ packages:
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
 
-  '@typescript-eslint/eslint-plugin@7.14.1':
-    resolution: {integrity: sha512-aAJd6bIf2vvQRjUG3ZkNXkmBpN+J7Wd0mfQiiVCJMu9Z5GcZZdcc0j8XwN/BM97Fl7e3SkTXODSk4VehUv7CGw==}
+  '@typescript-eslint/eslint-plugin@7.16.1':
+    resolution: {integrity: sha512-SxdPak/5bO0EnGktV05+Hq8oatjAYVY3Zh2bye9pGZy6+jwyR3LG3YKkV4YatlsgqXP28BTeVm9pqwJM96vf2A==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^7.0.0
@@ -1539,8 +1527,8 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/parser@7.14.1':
-    resolution: {integrity: sha512-8lKUOebNLcR0D7RvlcloOacTOWzOqemWEWkKSVpMZVF/XVcwjPR+3MD08QzbW9TCGJ+DwIc6zUSGZ9vd8cO1IA==}
+  '@typescript-eslint/parser@7.16.1':
+    resolution: {integrity: sha512-u+1Qx86jfGQ5i4JjK33/FnawZRpsLxRnKzGE6EABZ40KxVT/vWsiZFEBBHjFOljmmV3MBYOHEKi0Jm9hbAOClA==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
@@ -1553,8 +1541,12 @@ packages:
     resolution: {integrity: sha512-gPrFSsoYcsffYXTOZ+hT7fyJr95rdVe4kGVX1ps/dJ+DfmlnjFN/GcMxXcVkeHDKqsq6uAcVaQaIi3cFffmAbA==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
-  '@typescript-eslint/type-utils@7.14.1':
-    resolution: {integrity: sha512-/MzmgNd3nnbDbOi3LfasXWWe292+iuo+umJ0bCCMCPc1jLO/z2BQmWUUUXvXLbrQey/JgzdF/OV+I5bzEGwJkQ==}
+  '@typescript-eslint/scope-manager@7.16.1':
+    resolution: {integrity: sha512-nYpyv6ALte18gbMz323RM+vpFpTjfNdyakbf3nsLvF43uF9KeNC289SUEW3QLZ1xPtyINJ1dIsZOuWuSRIWygw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/type-utils@7.16.1':
+    resolution: {integrity: sha512-rbu/H2MWXN4SkjIIyWcmYBjlp55VT+1G3duFOIukTNFxr9PI35pLc2ydwAfejCEitCv4uztA07q0QWanOHC7dA==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
@@ -1567,8 +1559,21 @@ packages:
     resolution: {integrity: sha512-mL7zNEOQybo5R3AavY+Am7KLv8BorIv7HCYS5rKoNZKQD9tsfGUpO4KdAn3sSUvTiS4PQkr2+K0KJbxj8H9NDg==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
+  '@typescript-eslint/types@7.16.1':
+    resolution: {integrity: sha512-AQn9XqCzUXd4bAVEsAXM/Izk11Wx2u4H3BAfQVhSfzfDOm/wAON9nP7J5rpkCxts7E5TELmN845xTUCQrD1xIQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
   '@typescript-eslint/typescript-estree@7.14.1':
     resolution: {integrity: sha512-k5d0VuxViE2ulIO6FbxxSZaxqDVUyMbXcidC8rHvii0I56XZPv8cq+EhMns+d/EVIL41sMXqRbK3D10Oza1bbA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/typescript-estree@7.16.1':
+    resolution: {integrity: sha512-0vFPk8tMjj6apaAZ1HlwM8w7jbghC8jc1aRNJG5vN8Ym5miyhTQGMqU++kuBFDNKe9NcPeZ6x0zfSzV8xC1UlQ==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       typescript: '*'
@@ -1582,8 +1587,18 @@ packages:
     peerDependencies:
       eslint: ^8.56.0
 
+  '@typescript-eslint/utils@7.16.1':
+    resolution: {integrity: sha512-WrFM8nzCowV0he0RlkotGDujx78xudsxnGMBHI88l5J8wEhED6yBwaSLP99ygfrzAjsQvcYQ94quDwI0d7E1fA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+
   '@typescript-eslint/visitor-keys@7.14.1':
     resolution: {integrity: sha512-Crb+F75U1JAEtBeQGxSKwI60hZmmzaqA3z9sYsVm8X7W5cwLEm5bRe0/uXS6+MR/y8CVpKSR/ontIAIEPFcEkA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/visitor-keys@7.16.1':
+    resolution: {integrity: sha512-Qlzzx4sE4u3FsHTPQAAQFJFNOuqtuY0LFrZHwQ8IHK705XxBiWOFkfKRWu6niB7hwfgnwIpO4jTC75ozW1PHWg==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
   '@ungap/structured-clone@1.2.0':
@@ -2033,13 +2048,13 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  eslint@8.48.0:
-    resolution: {integrity: sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==}
+  eslint@8.56.0:
+    resolution: {integrity: sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
 
-  eslint@8.56.0:
-    resolution: {integrity: sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==}
+  eslint@8.57.0:
+    resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
 
@@ -2268,10 +2283,6 @@ packages:
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
-  ignore@5.2.4:
-    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
-    engines: {node: '>= 4'}
 
   ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
@@ -2716,6 +2727,11 @@ packages:
 
   prettier@3.3.2:
     resolution: {integrity: sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  prettier@3.3.3:
+    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -3311,12 +3327,19 @@ snapshots:
 
   '@angular-eslint/bundled-angular-compiler@17.5.2': {}
 
-  '@angular-eslint/template-parser@17.5.2(eslint@8.48.0)(typescript@5.2.2)':
+  '@angular-eslint/template-parser@17.5.2(eslint@8.57.0)(typescript@5.2.2)':
     dependencies:
       '@angular-eslint/bundled-angular-compiler': 17.5.2
-      eslint: 8.48.0
+      eslint: 8.57.0
       eslint-scope: 8.0.1
       typescript: 5.2.2
+
+  '@angular-eslint/template-parser@17.5.2(eslint@8.57.0)(typescript@5.5.3)':
+    dependencies:
+      '@angular-eslint/bundled-angular-compiler': 17.5.2
+      eslint: 8.57.0
+      eslint-scope: 8.0.1
+      typescript: 5.5.3
 
   '@angular/compiler@17.0.1':
     dependencies:
@@ -3770,33 +3793,17 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@8.48.0)':
-    dependencies:
-      eslint: 8.48.0
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.4.0(eslint@8.56.0)':
     dependencies:
       eslint: 8.56.0
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/regexpp@4.11.0': {}
-
-  '@eslint-community/regexpp@4.8.0': {}
-
-  '@eslint/eslintrc@2.1.2':
+  '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
     dependencies:
-      ajv: 6.12.6
-      debug: 4.3.4
-      espree: 9.6.1
-      globals: 13.21.0
-      ignore: 5.3.1
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
+      eslint: 8.57.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.11.0': {}
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
@@ -3812,17 +3819,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@8.48.0': {}
-
   '@eslint/js@8.56.0': {}
 
-  '@humanwhocodes/config-array@0.11.11':
-    dependencies:
-      '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
+  '@eslint/js@8.57.0': {}
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
@@ -3833,8 +3832,6 @@ snapshots:
       - supports-color
 
   '@humanwhocodes/module-importer@1.0.1': {}
-
-  '@humanwhocodes/object-schema@1.2.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
@@ -4181,14 +4178,14 @@ snapshots:
 
   '@types/semver@7.5.8': {}
 
-  '@typescript-eslint/eslint-plugin@7.14.1(@typescript-eslint/parser@7.14.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)':
+  '@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 7.14.1(eslint@8.56.0)(typescript@5.5.3)
-      '@typescript-eslint/scope-manager': 7.14.1
-      '@typescript-eslint/type-utils': 7.14.1(eslint@8.56.0)(typescript@5.5.3)
-      '@typescript-eslint/utils': 7.14.1(eslint@8.56.0)(typescript@5.5.3)
-      '@typescript-eslint/visitor-keys': 7.14.1
+      '@typescript-eslint/parser': 7.16.1(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/scope-manager': 7.16.1
+      '@typescript-eslint/type-utils': 7.16.1(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/utils': 7.16.1(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/visitor-keys': 7.16.1
       eslint: 8.56.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -4199,14 +4196,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.14.1(eslint@8.56.0)(typescript@5.5.3)':
+  '@typescript-eslint/parser@7.16.1(eslint@8.56.0)(typescript@5.5.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 7.14.1
-      '@typescript-eslint/types': 7.14.1
-      '@typescript-eslint/typescript-estree': 7.14.1(typescript@5.5.3)
-      '@typescript-eslint/visitor-keys': 7.14.1
+      '@typescript-eslint/scope-manager': 7.16.1
+      '@typescript-eslint/types': 7.16.1
+      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.5.3)
+      '@typescript-eslint/visitor-keys': 7.16.1
       debug: 4.3.4
       eslint: 8.56.0
+    optionalDependencies:
+      typescript: 5.5.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 7.16.1
+      '@typescript-eslint/types': 7.16.1
+      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.5.3)
+      '@typescript-eslint/visitor-keys': 7.16.1
+      debug: 4.3.4
+      eslint: 8.57.0
     optionalDependencies:
       typescript: 5.5.3
     transitivePeerDependencies:
@@ -4217,10 +4227,15 @@ snapshots:
       '@typescript-eslint/types': 7.14.1
       '@typescript-eslint/visitor-keys': 7.14.1
 
-  '@typescript-eslint/type-utils@7.14.1(eslint@8.56.0)(typescript@5.5.3)':
+  '@typescript-eslint/scope-manager@7.16.1':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.14.1(typescript@5.5.3)
-      '@typescript-eslint/utils': 7.14.1(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/types': 7.16.1
+      '@typescript-eslint/visitor-keys': 7.16.1
+
+  '@typescript-eslint/type-utils@7.16.1(eslint@8.56.0)(typescript@5.5.3)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.5.3)
+      '@typescript-eslint/utils': 7.16.1(eslint@8.56.0)(typescript@5.5.3)
       debug: 4.3.4
       eslint: 8.56.0
       ts-api-utils: 1.3.0(typescript@5.5.3)
@@ -4231,10 +4246,27 @@ snapshots:
 
   '@typescript-eslint/types@7.14.1': {}
 
+  '@typescript-eslint/types@7.16.1': {}
+
   '@typescript-eslint/typescript-estree@7.14.1(typescript@5.5.3)':
     dependencies:
       '@typescript-eslint/types': 7.14.1
       '@typescript-eslint/visitor-keys': 7.14.1
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.6.2
+      ts-api-utils: 1.3.0(typescript@5.5.3)
+    optionalDependencies:
+      typescript: 5.5.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@7.16.1(typescript@5.5.3)':
+    dependencies:
+      '@typescript-eslint/types': 7.16.1
+      '@typescript-eslint/visitor-keys': 7.16.1
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
@@ -4257,9 +4289,25 @@ snapshots:
       - supports-color
       - typescript
 
+  '@typescript-eslint/utils@7.16.1(eslint@8.56.0)(typescript@5.5.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
+      '@typescript-eslint/scope-manager': 7.16.1
+      '@typescript-eslint/types': 7.16.1
+      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.5.3)
+      eslint: 8.56.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/visitor-keys@7.14.1':
     dependencies:
       '@typescript-eslint/types': 7.14.1
+      eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@7.16.1':
+    dependencies:
+      '@typescript-eslint/types': 7.16.1
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.2.0': {}
@@ -4831,12 +4879,12 @@ snapshots:
     dependencies:
       eslint: 8.56.0
 
-  eslint-plugin-vitest@0.4.1(@typescript-eslint/eslint-plugin@7.14.1(@typescript-eslint/parser@7.14.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)(vitest@1.6.0(@types/node@20.14.10)):
+  eslint-plugin-vitest@0.4.1(@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)(vitest@1.6.0(@types/node@20.14.10)):
     dependencies:
       '@typescript-eslint/utils': 7.14.1(eslint@8.56.0)(typescript@5.5.3)
       eslint: 8.56.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 7.14.1(@typescript-eslint/parser@7.14.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/eslint-plugin': 7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)
       vitest: 1.6.0(@types/node@20.14.10)
     transitivePeerDependencies:
       - supports-color
@@ -4854,15 +4902,16 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint@8.48.0:
+  eslint@8.56.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.48.0)
-      '@eslint-community/regexpp': 4.8.0
-      '@eslint/eslintrc': 2.1.2
-      '@eslint/js': 8.48.0
-      '@humanwhocodes/config-array': 0.11.11
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
+      '@eslint-community/regexpp': 4.11.0
+      '@eslint/eslintrc': 2.1.4
+      '@eslint/js': 8.56.0
+      '@humanwhocodes/config-array': 0.11.14
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
+      '@ungap/structured-clone': 1.2.0
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
@@ -4880,7 +4929,7 @@ snapshots:
       glob-parent: 6.0.2
       globals: 13.21.0
       graphemer: 1.4.0
-      ignore: 5.2.4
+      ignore: 5.3.1
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
@@ -4896,12 +4945,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint@8.56.0:
+  eslint@8.57.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@eslint-community/regexpp': 4.11.0
       '@eslint/eslintrc': 2.1.4
-      '@eslint/js': 8.56.0
+      '@eslint/js': 8.57.0
       '@humanwhocodes/config-array': 0.11.14
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
@@ -5173,8 +5222,6 @@ snapshots:
   hyperdyperid@1.2.0: {}
 
   ieee754@1.2.1: {}
-
-  ignore@5.2.4: {}
 
   ignore@5.3.1: {}
 
@@ -5629,6 +5676,8 @@ snapshots:
       fast-diff: 1.3.0
 
   prettier@3.3.2: {}
+
+  prettier@3.3.3: {}
 
   pretty-format@29.7.0:
     dependencies:
@@ -6202,10 +6251,10 @@ snapshots:
 
   vm-browserify@1.1.2: {}
 
-  vue-eslint-parser@9.3.2(eslint@8.48.0):
+  vue-eslint-parser@9.3.2(eslint@8.57.0):
     dependencies:
       debug: 4.3.4
-      eslint: 8.48.0
+      eslint: 8.57.0
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1


### PR DESCRIPTION
vue parser used for transformations was not configured to use the typescript parser.
In this PR we add the typescript parser to the dependencies and we configure vue parser to use it for ts files.
Also, we update some packages