### PR TITLE
AG-12929 Update for 32.2.1

### DIFF
--- a/packages/cli/src/codemods/plugins/transform-grid-options/transform-grid-options.ts
+++ b/packages/cli/src/codemods/plugins/transform-grid-options/transform-grid-options.ts
@@ -873,7 +873,12 @@ export function migrateDeepProperty<S extends AstTransformContext<AstCliContext>
       // Fish out the reference to the object expression
       const jsxExpressionContainer = rootSibling?.get('value');
       if (!jsxExpressionContainer?.isJSXExpressionContainer()) return;
-      const objExp = jsxExpressionContainer.get('expression');
+      let objExp = jsxExpressionContainer.get('expression');
+      if (!objExp.isObjectExpression()) {
+        // overwrite value with a new object expression
+        const [transformed] = objExp.replaceWith(t.objectExpression([]));
+        objExp = transformed;
+      }
       if (!objExp.isObjectExpression()) return;
 
       // This loop is doing largely the same thing as the loop in the `.init` transformer:
@@ -906,6 +911,10 @@ export function migrateDeepProperty<S extends AstTransformContext<AstCliContext>
         }
       }
 
+      const key = node.get('name');
+      if (key.isJSXIdentifier() && key.node.name === path[0]) {
+        return;
+      }
       node.remove();
     },
 

--- a/packages/cli/src/codemods/plugins/transform-grid-options/transform-grid-options.ts
+++ b/packages/cli/src/codemods/plugins/transform-grid-options/transform-grid-options.ts
@@ -795,6 +795,10 @@ export function migrateDeepProperty<S extends AstTransformContext<AstCliContext>
         }
       }
 
+      const key = node.get('key');
+      if (key.isIdentifier() && key.node.name === path[0]) {
+        return;
+      }
       node.remove();
     },
 

--- a/packages/cli/src/codemods/plugins/transform-grid-options/transform-grid-options.ts
+++ b/packages/cli/src/codemods/plugins/transform-grid-options/transform-grid-options.ts
@@ -777,7 +777,15 @@ export function migrateDeepProperty<S extends AstTransformContext<AstCliContext>
           initializer = createSiblingPropertyInitializer(rootNode, rootAccessor);
         }
         if (!initializer) return;
-        const newObj = initializer.get('value');
+        let newObj = initializer.get('value');
+        if (!newObj.isObjectExpression()) {
+          // overwrite value with a new object expression
+          const [transformed] = initializer.replaceWith(
+            t.objectProperty(initializer.node.key, t.objectExpression([])),
+          );
+          initializer = transformed;
+          newObj = initializer.get('value') as NodePath<ObjectExpression>;
+        }
         if (!newObj.isObjectExpression()) return;
         rootNode = newObj;
 
@@ -876,7 +884,15 @@ export function migrateDeepProperty<S extends AstTransformContext<AstCliContext>
           initializer = createSiblingPropertyInitializer(rootNode, accessor);
         }
         if (!initializer) return;
-        const newObj = initializer.get('value');
+        let newObj = initializer.get('value');
+        if (!newObj.isObjectExpression()) {
+          // overwrite value with a new object expression
+          const [transformed] = initializer.replaceWith(
+            t.objectProperty(initializer.node.key, t.objectExpression([])),
+          );
+          initializer = transformed;
+          newObj = initializer.get('value') as NodePath<ObjectExpression>;
+        }
         if (!newObj.isObjectExpression()) return;
         rootNode = newObj;
 

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/angular/warnings/output.component.ts
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/angular/warnings/output.component.ts
@@ -18,7 +18,7 @@ import { IOlympicData } from './interfaces';
       [rowMultiSelectWithClick]="true"
       [groupSelectsChildren]="true"
       [groupSelectsFiltered]="true"
-      [enableRangeSelection]="true"
+      [cellSelection]="true"
       [suppressMultiRangeSelection]="true"
       [suppressClearOnFillReduction]="true"
       [enableRangeHandle]="true"

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/angular/warnings/output.warnings.cjs
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/angular/warnings/output.warnings.cjs
@@ -6,7 +6,6 @@ module.exports = [
     new SyntaxError('The grid option "rowMultiSelectWithClick" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/'),
     new SyntaxError('The grid option "groupSelectsChildren" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/'),
     new SyntaxError('The grid option "groupSelectsFiltered" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/'),
-    new SyntaxError('The grid option "enableRangeSelection" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/'),
     new SyntaxError('The grid option "suppressMultiRangeSelection" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/'),
     new SyntaxError('The grid option "suppressClearOnFillReduction" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/'),
     new SyntaxError('The grid option "enableRangeHandle" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/'),

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection-expressions/output.js
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection-expressions/output.js
@@ -17,13 +17,16 @@ const gridApi = createGrid(document.body, {
   onCellSelectionChanged: onRangeSelectionChanged,
   onCellSelectionDeleteStart: foo,
   onCellSelectionDeleteEnd: () => {},
-  enableRangeSelection: cellSelection,
+
+  cellSelection: {
+    suppressMultiRanges: suppressMultiRangeSelection,
+
+    handle: {
+      suppressClearOnFillReduction: suppressClearOnFillReduction
+    }
+  },
+
   enableRangeHandle: isEnableRangeHandle(),
   suppressCopyRowsToClipboard: true,
-  suppressCopySingleCellRanges: true,
-
-  selection: {
-    suppressMultiRanges: suppressMultiRangeSelection,
-    suppressClearOnFillReduction: suppressClearOnFillReduction
-  }
+  suppressCopySingleCellRanges: true
 });

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection-expressions/output.js
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection-expressions/output.js
@@ -18,15 +18,11 @@ const gridApi = createGrid(document.body, {
   onCellSelectionDeleteStart: foo,
   onCellSelectionDeleteEnd: () => {},
 
-  cellSelection: {
-    suppressMultiRanges: suppressMultiRangeSelection,
-
-    handle: {
-      suppressClearOnFillReduction: suppressClearOnFillReduction
-    }
-  },
-
+  cellSelection: cellSelection,
   enableRangeHandle: isEnableRangeHandle(),
+  suppressMultiRangeSelection: suppressMultiRangeSelection,
+  suppressClearOnFillReduction,
+
   suppressCopyRowsToClipboard: true,
-  suppressCopySingleCellRanges: true
+  suppressCopySingleCellRanges: true,
 });

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection-expressions/output.warnings.cjs
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection-expressions/output.warnings.cjs
@@ -1,12 +1,16 @@
 module.exports = [
-    new SyntaxError(`The grid option "enableRangeSelection" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
-
-> |   enableRangeSelection: cellSelection,
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`),
   new SyntaxError(`The grid option "enableRangeHandle" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
 
 > |   enableRangeHandle: isEnableRangeHandle(),
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`),
+  new SyntaxError(`The grid option "suppressMultiRangeSelection" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |   suppressMultiRangeSelection: suppressMultiRangeSelection,
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`),
+  new SyntaxError(`The grid option "suppressClearOnFillReduction" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |   suppressClearOnFillReduction,
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^`),
     new SyntaxError(`The grid option "suppressCopyRowsToClipboard" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
 
 > |   suppressCopyRowsToClipboard: true,

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection-fill-handle/output.js
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection-fill-handle/output.js
@@ -16,17 +16,13 @@ const gridApi = createGrid(document.body, {
   onCellSelectionDeleteStart: foo,
   onCellSelectionDeleteEnd: () => {},
 
-  cellSelection: {
-    handle: {
-      mode: "fill",
-      suppressClearOnFillReduction: suppressClearOnFillReduction,
-      direction: getFillDirection(),
-      setFillValue: () => {console.log('filling')}
-    },
-
-    suppressMultiRanges: suppressMultiRangeSelection
-  },
+  cellSelection: true,
+  enableFillHandle: true,
+  suppressMultiRangeSelection: suppressMultiRangeSelection,
+  suppressClearOnFillReduction,
+  fillHandleDirection: getFillDirection(),
+  fillOperation: () => {console.log('filling')},
 
   suppressCopyRowsToClipboard: true,
-  suppressCopySingleCellRanges: true
+  suppressCopySingleCellRanges: true,
 });

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection-fill-handle/output.js
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection-fill-handle/output.js
@@ -15,19 +15,18 @@ const gridApi = createGrid(document.body, {
   onCellSelectionChanged: onRangeSelectionChanged,
   onCellSelectionDeleteStart: foo,
   onCellSelectionDeleteEnd: () => {},
-  suppressCopyRowsToClipboard: true,
-  suppressCopySingleCellRanges: true,
 
-  selection: {
-    mode: "cell",
-
+  cellSelection: {
     handle: {
       mode: "fill",
+      suppressClearOnFillReduction: suppressClearOnFillReduction,
       direction: getFillDirection(),
       setFillValue: () => {console.log('filling')}
     },
 
-    suppressMultiRanges: suppressMultiRangeSelection,
-    suppressClearOnFillReduction: suppressClearOnFillReduction
-  }
+    suppressMultiRanges: suppressMultiRangeSelection
+  },
+
+  suppressCopyRowsToClipboard: true,
+  suppressCopySingleCellRanges: true
 });

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection-fill-handle/output.warnings.cjs
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection-fill-handle/output.warnings.cjs
@@ -1,4 +1,24 @@
 module.exports = [
+new SyntaxError(`The grid option "enableFillHandle" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |   enableFillHandle: true,
+  |   ^^^^^^^^^^^^^^^^^^^^^^`),
+  new SyntaxError(`The grid option "suppressMultiRangeSelection" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |   suppressMultiRangeSelection: suppressMultiRangeSelection,
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`),
+  new SyntaxError(`The grid option "suppressClearOnFillReduction" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |   suppressClearOnFillReduction,
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^`),
+  new SyntaxError(`The grid option "fillHandleDirection" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |   fillHandleDirection: getFillDirection(),
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`),
+  new SyntaxError(`The grid option "fillOperation" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |   fillOperation: () => {console.log('filling')},
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`),
     new SyntaxError(`The grid option "suppressCopyRowsToClipboard" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
 
 > |   suppressCopyRowsToClipboard: true,

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection/output.js
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection/output.js
@@ -13,17 +13,16 @@ const gridApi = createGrid(document.body, {
   onCellSelectionChanged: onRangeSelectionChanged,
   onCellSelectionDeleteStart: foo,
   onCellSelectionDeleteEnd: () => {},
-  suppressCopyRowsToClipboard: true,
-  suppressCopySingleCellRanges: true,
 
-  selection: {
-    mode: "cell",
-
+  cellSelection: {
     handle: {
-      mode: "range"
+      mode: "range",
+      suppressClearOnFillReduction: suppressClearOnFillReduction
     },
 
-    suppressMultiRanges: suppressMultiRangeSelection,
-    suppressClearOnFillReduction: suppressClearOnFillReduction
-  }
+    suppressMultiRanges: suppressMultiRangeSelection
+  },
+
+  suppressCopyRowsToClipboard: true,
+  suppressCopySingleCellRanges: true
 });

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection/output.js
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection/output.js
@@ -14,15 +14,11 @@ const gridApi = createGrid(document.body, {
   onCellSelectionDeleteStart: foo,
   onCellSelectionDeleteEnd: () => {},
 
-  cellSelection: {
-    handle: {
-      mode: "range",
-      suppressClearOnFillReduction: suppressClearOnFillReduction
-    },
-
-    suppressMultiRanges: suppressMultiRangeSelection
-  },
+  cellSelection: true,
+  enableRangeHandle: true,
+  suppressMultiRangeSelection: suppressMultiRangeSelection,
+  suppressClearOnFillReduction,
 
   suppressCopyRowsToClipboard: true,
-  suppressCopySingleCellRanges: true
+  suppressCopySingleCellRanges: true,
 });

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection/output.warnings.cjs
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/cell-selection/output.warnings.cjs
@@ -1,4 +1,16 @@
 module.exports = [
+    new SyntaxError(`The grid option "enableRangeHandle" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |   enableRangeHandle: true,
+  |   ^^^^^^^^^^^^^^^^^^^^^^^`),
+    new SyntaxError(`The grid option "suppressMultiRangeSelection" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |   suppressMultiRangeSelection: suppressMultiRangeSelection,
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`),
+  new SyntaxError(`The grid option "suppressClearOnFillReduction" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |   suppressClearOnFillReduction,
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^`),
     new SyntaxError(`The grid option "suppressCopyRowsToClipboard" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
 
 > |   suppressCopyRowsToClipboard: true,

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/columnDefs/output.js
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/columnDefs/output.js
@@ -16,7 +16,7 @@ const gridApi = createGrid(document.body, {
 
   rowData: [],
 
-  selection: {
+  rowSelection: {
     mode: "multiRow"
   }
 });

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/columnDefs/output.js
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/columnDefs/output.js
@@ -13,9 +13,7 @@ const gridApi = createGrid(document.body, {
     headerCheckboxSelection: true,
     headerCheckboxSelectionCurrentPageOnly: true,
   }],
-
   rowData: [],
-
   rowSelection: {
     mode: "multiRow"
   }

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/multi-row-selection/output.js
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/multi-row-selection/output.js
@@ -6,16 +6,17 @@ const gridApi = createGrid(document.body, {
   onCellSelectionChanged: () => {},
   onCellSelectionDeleteStart: () => {},
   onCellSelectionDeleteEnd: () => {},
-  suppressRowClickSelection: true,
-  suppressRowDeselection: true,
-  groupSelectsChildren: true,
-  groupSelectsFiltered: true,
-  suppressCopyRowsToClipboard: true,
-  suppressCopySingleCellRanges: true,
 
   rowSelection: {
     mode: "multiRow",
     isRowSelectable: (params) => params.data.year < 2007,
     enableSelectionWithoutKeys: true
-  }
+  },
+
+  suppressRowClickSelection: true,
+  suppressRowDeselection: true,
+  groupSelectsChildren: true,
+  groupSelectsFiltered: true,
+  suppressCopyRowsToClipboard: true,
+  suppressCopySingleCellRanges: true
 });

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/multi-row-selection/output.js
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/multi-row-selection/output.js
@@ -13,9 +13,9 @@ const gridApi = createGrid(document.body, {
   suppressCopyRowsToClipboard: true,
   suppressCopySingleCellRanges: true,
 
-  selection: {
+  rowSelection: {
     mode: "multiRow",
     isRowSelectable: (params) => params.data.year < 2007,
-    enableMultiSelectWithClick: true
+    enableSelectionWithoutKeys: true
   }
 });

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/single-row-selection/output.js
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/single-row-selection/output.js
@@ -6,13 +6,14 @@ const gridApi = createGrid(document.body, {
   onCellSelectionChanged: () => {},
   onCellSelectionDeleteStart: () => {},
   onCellSelectionDeleteEnd: () => {},
-  suppressRowClickSelection: true,
-  suppressRowDeselection: true,
-  suppressCopyRowsToClipboard: true,
-  suppressCopySingleCellRanges: true,
 
   rowSelection: {
     mode: "singleRow",
     isRowSelectable: (params) => params.data.year < 2007
-  }
+  },
+
+  suppressRowClickSelection: true,
+  suppressRowDeselection: true,
+  suppressCopyRowsToClipboard: true,
+  suppressCopySingleCellRanges: true
 });

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/single-row-selection/output.js
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/js/single-row-selection/output.js
@@ -11,7 +11,7 @@ const gridApi = createGrid(document.body, {
   suppressCopyRowsToClipboard: true,
   suppressCopySingleCellRanges: true,
 
-  selection: {
+  rowSelection: {
     mode: "singleRow",
     isRowSelectable: (params) => params.data.year < 2007
   }

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/cell-selection-fill-handle/output.jsx
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/cell-selection-fill-handle/output.jsx
@@ -10,22 +10,19 @@ function foo() {}
 function MyComponent(props) {
   return (
     (<AgGridReact
-      columnDefs={[]}
-      rowData={[]}
-      onCellSelectionChanged={onRangeSelectionChanged}
-      onCellSelectionDeleteStart={foo}
-      onCellSelectionDeleteEnd={() => {}}
-      suppressCopyRowsToClipboard={true}
-      suppressCopySingleCellRanges={true}
-      cellSelection={{
-        suppressMultiRanges: suppressMultiRangeSelection,
-
-        handle: {
-          suppressClearOnFillReduction: suppressClearOnFillReduction,
-          mode: "fill",
-          direction: 'x',
-          setFillValue: () => {console.log('filling')}
-        }
-      }} />)
+        columnDefs={[]}
+        rowData={[]}
+        onCellSelectionChanged={onRangeSelectionChanged}
+        onCellSelectionDeleteStart={foo}
+        onCellSelectionDeleteEnd={() => {}}
+        cellSelection={true}
+        suppressMultiRangeSelection={suppressMultiRangeSelection}
+        suppressClearOnFillReduction={suppressClearOnFillReduction}
+        enableFillHandle={true}
+        fillHandleDirection={'x'}
+        fillOperation={() => {console.log('filling')}}
+        suppressCopyRowsToClipboard={true}
+        suppressCopySingleCellRanges={true}
+      />)
   );
 }

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/cell-selection-fill-handle/output.jsx
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/cell-selection-fill-handle/output.jsx
@@ -17,12 +17,11 @@ function MyComponent(props) {
       onCellSelectionDeleteEnd={() => {}}
       suppressCopyRowsToClipboard={true}
       suppressCopySingleCellRanges={true}
-      selection={{
-        mode: "cell",
+      cellSelection={{
         suppressMultiRanges: suppressMultiRangeSelection,
-        suppressClearOnFillReduction: suppressClearOnFillReduction,
 
         handle: {
+          suppressClearOnFillReduction: suppressClearOnFillReduction,
           mode: "fill",
           direction: 'x',
           setFillValue: () => {console.log('filling')}

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/cell-selection-fill-handle/output.warnings.cjs
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/cell-selection-fill-handle/output.warnings.cjs
@@ -1,4 +1,23 @@
 module.exports = [
+  new SyntaxError(`The grid option "suppressMultiRangeSelection" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |       suppressMultiRangeSelection={suppressMultiRangeSelection}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`),
+  new SyntaxError(`The grid option "suppressClearOnFillReduction" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |       suppressClearOnFillReduction={suppressClearOnFillReduction}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`),
+  new SyntaxError(`The grid option "enableFillHandle" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |       enableFillHandle={true}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^`),
+  new SyntaxError(`The grid option "fillHandleDirection" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |       fillHandleDirection={'x'}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^`),new SyntaxError(`The grid option "fillOperation" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |       fillOperation={() => {console.log('filling')}}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`),
     new SyntaxError(`The grid option "suppressCopyRowsToClipboard" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
 
 > |       suppressCopyRowsToClipboard={true}

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/cell-selection/input.jsx
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/cell-selection/input.jsx
@@ -9,7 +9,7 @@ function foo() {}
 
 function MyComponent (props) {
   return (
-    <AgGridReact 
+    <AgGridReact
       columnDefs={[]}
       rowData={[]}
       onRangeSelectionChanged={onRangeSelectionChanged}

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/cell-selection/output.jsx
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/cell-selection/output.jsx
@@ -15,15 +15,14 @@ function MyComponent (props) {
       onCellSelectionChanged={onRangeSelectionChanged}
       onCellSelectionDeleteStart={foo}
       onCellSelectionDeleteEnd={() => {}}
+
+      cellSelection={true}
+      enableRangeHandle={true}
+      suppressMultiRangeSelection={suppressMultiRangeSelection}
+      suppressClearOnFillReduction={suppressClearOnFillReduction}
+
       suppressCopyRowsToClipboard={true}
       suppressCopySingleCellRanges={true}
-      cellSelection={{
-        handle: {
-          mode: "range",
-          suppressClearOnFillReduction: suppressClearOnFillReduction
-        },
-
-        suppressMultiRanges: suppressMultiRangeSelection
-      }} />)
+    />)
   );
 }

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/cell-selection/output.jsx
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/cell-selection/output.jsx
@@ -17,15 +17,13 @@ function MyComponent (props) {
       onCellSelectionDeleteEnd={() => {}}
       suppressCopyRowsToClipboard={true}
       suppressCopySingleCellRanges={true}
-      selection={{
-        mode: "cell",
-
+      cellSelection={{
         handle: {
-          mode: "range"
+          mode: "range",
+          suppressClearOnFillReduction: suppressClearOnFillReduction
         },
 
-        suppressMultiRanges: suppressMultiRangeSelection,
-        suppressClearOnFillReduction: suppressClearOnFillReduction
+        suppressMultiRanges: suppressMultiRangeSelection
       }} />)
   );
 }

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/cell-selection/output.warnings.cjs
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/cell-selection/output.warnings.cjs
@@ -1,4 +1,16 @@
 module.exports = [
+  new SyntaxError(`The grid option "enableRangeHandle" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |       enableRangeHandle={true}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^`),
+  new SyntaxError(`The grid option "suppressMultiRangeSelection" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |       suppressMultiRangeSelection={suppressMultiRangeSelection}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`),
+  new SyntaxError(`The grid option "suppressClearOnFillReduction" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
+
+> |       suppressClearOnFillReduction={suppressClearOnFillReduction}
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`),
     new SyntaxError(`The grid option "suppressCopyRowsToClipboard" cannot be automatically migrated. Please refer to the migration guide for more details: https://ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-32-2/
 
 > |       suppressCopyRowsToClipboard={true}

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/multi-row-selection/output.jsx
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/multi-row-selection/output.jsx
@@ -5,6 +5,11 @@ function MyComponent(props) {
     (<AgGridReact
       columnDefs={[]}
       rowData={[]}
+      rowSelection={{
+        mode: "multiRow",
+        isRowSelectable: (params) => params.data.year < 2007,
+        enableSelectionWithoutKeys: true
+      }}
       onCellSelectionChanged={() => {}}
       onCellSelectionDeleteStart={() => {}}
       onCellSelectionDeleteEnd={() => {}}
@@ -13,11 +18,6 @@ function MyComponent(props) {
       groupSelectsChildren
       groupSelectsFiltered
       suppressCopyRowsToClipboard
-      suppressCopySingleCellRanges
-      rowSelection={{
-        mode: "multiRow",
-        isRowSelectable: (params) => params.data.year < 2007,
-        enableMultiSelectWithClick: true
-      }} />)
+      suppressCopySingleCellRanges />)
   );
 }

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/multi-row-selection/output.jsx
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/multi-row-selection/output.jsx
@@ -14,7 +14,7 @@ function MyComponent(props) {
       groupSelectsFiltered
       suppressCopyRowsToClipboard
       suppressCopySingleCellRanges
-      selection={{
+      rowSelection={{
         mode: "multiRow",
         isRowSelectable: (params) => params.data.year < 2007,
         enableMultiSelectWithClick: true

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/single-row-selection-expressions/output.jsx
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/single-row-selection-expressions/output.jsx
@@ -7,7 +7,6 @@ function MyComponent(props) {
     (<AgGridReact
       columnDefs={[]}
       rowData={[]}
-      rowSelection={selectionState}
       onCellSelectionChanged={() => {}}
       onCellSelectionDeleteStart={() => {}}
       onCellSelectionDeleteEnd={() => {}}
@@ -15,7 +14,7 @@ function MyComponent(props) {
       suppressRowDeselection
       suppressCopyRowsToClipboard
       suppressCopySingleCellRanges
-      selection={{
+      rowSelection={{
         isRowSelectable: (params) => params.data.year < 2007
       }} />)
   );

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/single-row-selection-expressions/output.jsx
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/single-row-selection-expressions/output.jsx
@@ -7,15 +7,15 @@ function MyComponent(props) {
     (<AgGridReact
       columnDefs={[]}
       rowData={[]}
+      rowSelection={{
+        isRowSelectable: (params) => params.data.year < 2007
+      }}
       onCellSelectionChanged={() => {}}
       onCellSelectionDeleteStart={() => {}}
       onCellSelectionDeleteEnd={() => {}}
       suppressRowClickSelection
       suppressRowDeselection
       suppressCopyRowsToClipboard
-      suppressCopySingleCellRanges
-      rowSelection={{
-        isRowSelectable: (params) => params.data.year < 2007
-      }} />)
+      suppressCopySingleCellRanges />)
   );
 }

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/single-row-selection/output.jsx
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/single-row-selection/output.jsx
@@ -5,16 +5,16 @@ function MyComponent(props) {
     (<AgGridReact
       columnDefs={[]}
       rowData={[]}
+      rowSelection={{
+        mode: "singleRow",
+        isRowSelectable: (params) => params.data.year < 2007
+      }}
       onCellSelectionChanged={() => {}}
       onCellSelectionDeleteStart={() => {}}
       onCellSelectionDeleteEnd={() => {}}
       suppressRowClickSelection
       suppressRowDeselection
       suppressCopyRowsToClipboard
-      suppressCopySingleCellRanges
-      rowSelection={{
-        mode: "singleRow",
-        isRowSelectable: (params) => params.data.year < 2007
-      }} />)
+      suppressCopySingleCellRanges />)
   );
 }

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/single-row-selection/output.jsx
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/__fixtures__/scenarios/jsx/single-row-selection/output.jsx
@@ -12,7 +12,7 @@ function MyComponent(props) {
       suppressRowDeselection
       suppressCopyRowsToClipboard
       suppressCopySingleCellRanges
-      selection={{
+      rowSelection={{
         mode: "singleRow",
         isRowSelectable: (params) => params.data.year < 2007
       }} />)

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/replacements.ts
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/replacements.ts
@@ -47,7 +47,7 @@ export const replacements: Array<CodemodObjectPropertyReplacement> = transformOb
   onRangeDeleteEnd: migrateProperty('onCellSelectionDeleteEnd', migrateOptionalValue()),
 
   rowSelection: migrateDeepProperty(
-    ['selection', 'mode'],
+    ['rowSelection', 'mode'],
     transformOptionalValue(apply(transformRowSelection)),
     getManualInterventionMessage('rowSelection', MIGRATION_URL),
   ),
@@ -58,12 +58,12 @@ export const replacements: Array<CodemodObjectPropertyReplacement> = transformOb
     getManualInterventionMessage('suppressRowDeselection', MIGRATION_URL),
   ),
   isRowSelectable: migrateDeepProperty(
-    ['selection', 'isRowSelectable'],
+    ['rowSelection', 'isRowSelectable'],
     migrateOptionalValue(),
     getManualInterventionMessage('isRowSelectable', MIGRATION_URL),
   ),
   rowMultiSelectWithClick: migrateDeepProperty(
-    ['selection', 'enableMultiSelectWithClick'],
+    ['rowSelection', 'enableSelectionWithoutKeys'],
     migrateOptionalValue(),
     getManualInterventionMessage('rowMultiSelectWithClick', MIGRATION_URL),
   ),
@@ -75,38 +75,37 @@ export const replacements: Array<CodemodObjectPropertyReplacement> = transformOb
     getManualInterventionMessage('groupSelectsFiltered', MIGRATION_URL),
   ),
 
-  enableRangeSelection: migrateDeepProperty(
-    ['selection', 'mode'],
-    transformOptionalValue(apply(transformCellSelection)),
-    getManualInterventionMessage('enableRangeSelection', MIGRATION_URL),
-  ),
+  // Migration of this must come before all other cell selection properties.
+  // If no other cell selection properties are specified,
+  enableRangeSelection: migrateProperty('cellSelection', migrateOptionalValue()),
+
   suppressMultiRangeSelection: migrateDeepProperty(
-    ['selection', 'suppressMultiRanges'],
+    ['cellSelection', 'suppressMultiRanges'],
     migrateOptionalValue(),
     getManualInterventionMessage('suppressMultiRangeSelection', MIGRATION_URL),
   ),
   suppressClearOnFillReduction: migrateDeepProperty(
-    ['selection', 'suppressClearOnFillReduction'],
+    ['cellSelection', 'handle', 'suppressClearOnFillReduction'],
     migrateOptionalValue(),
     getManualInterventionMessage('suppressClearOnFillReduction', MIGRATION_URL),
   ),
   enableRangeHandle: migrateDeepProperty(
-    ['selection', 'handle', 'mode'],
+    ['cellSelection', 'handle', 'mode'],
     transformOptionalValue(apply(transformRangeHandle)),
     getManualInterventionMessage('enableRangeHandle', MIGRATION_URL),
   ),
   enableFillHandle: migrateDeepProperty(
-    ['selection', 'handle', 'mode'],
+    ['cellSelection', 'handle', 'mode'],
     transformOptionalValue(apply(transformFillHandle)),
     getManualInterventionMessage('enableFillHandle', MIGRATION_URL),
   ),
   fillHandleDirection: migrateDeepProperty(
-    ['selection', 'handle', 'direction'],
+    ['cellSelection', 'handle', 'direction'],
     migrateOptionalValue(),
     getManualInterventionMessage('fillHandleDirection', MIGRATION_URL),
   ),
   fillOperation: migrateDeepProperty(
-    ['selection', 'handle', 'setFillValue'],
+    ['cellSelection', 'handle', 'setFillValue'],
     migrateOptionalValue(),
     getManualInterventionMessage('fillOperation', MIGRATION_URL),
   ),
@@ -154,11 +153,11 @@ function transformRowSelection(value: ObjectPropertyValue): t.Expression | null 
 }
 
 function transformCellSelection(value: ObjectPropertyValue): t.Expression | null {
-  if (value.isBooleanLiteral()) {
-    if (value.node.value) {
-      return ast.expression`'cell'`;
-    }
-  }
+  // if (value.isBooleanLiteral()) {
+  //   if (value.node.value) {
+  //     return ast.expression`'cell'`;
+  //   }
+  // }
 
   return null;
 }

--- a/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/replacements.ts
+++ b/packages/cli/src/codemods/transforms/transform-grid-options-v32-2/replacements.ts
@@ -1,4 +1,5 @@
 import {
+  frameworkWarning,
   getManualInterventionMessage,
   isNonNullJsxPropertyValue,
   migrateDeepProperty,
@@ -75,40 +76,22 @@ export const replacements: Array<CodemodObjectPropertyReplacement> = transformOb
     getManualInterventionMessage('groupSelectsFiltered', MIGRATION_URL),
   ),
 
-  // Migration of this must come before all other cell selection properties.
-  // If no other cell selection properties are specified,
   enableRangeSelection: migrateProperty('cellSelection', migrateOptionalValue()),
 
-  suppressMultiRangeSelection: migrateDeepProperty(
-    ['cellSelection', 'suppressMultiRanges'],
-    migrateOptionalValue(),
+  suppressMultiRangeSelection: removeProperty(
     getManualInterventionMessage('suppressMultiRangeSelection', MIGRATION_URL),
   ),
-  suppressClearOnFillReduction: migrateDeepProperty(
-    ['cellSelection', 'handle', 'suppressClearOnFillReduction'],
-    migrateOptionalValue(),
+  suppressClearOnFillReduction: removeProperty(
     getManualInterventionMessage('suppressClearOnFillReduction', MIGRATION_URL),
   ),
-  enableRangeHandle: migrateDeepProperty(
-    ['cellSelection', 'handle', 'mode'],
-    transformOptionalValue(apply(transformRangeHandle)),
+  enableRangeHandle: removeProperty(
     getManualInterventionMessage('enableRangeHandle', MIGRATION_URL),
   ),
-  enableFillHandle: migrateDeepProperty(
-    ['cellSelection', 'handle', 'mode'],
-    transformOptionalValue(apply(transformFillHandle)),
-    getManualInterventionMessage('enableFillHandle', MIGRATION_URL),
-  ),
-  fillHandleDirection: migrateDeepProperty(
-    ['cellSelection', 'handle', 'direction'],
-    migrateOptionalValue(),
+  enableFillHandle: removeProperty(getManualInterventionMessage('enableFillHandle', MIGRATION_URL)),
+  fillHandleDirection: removeProperty(
     getManualInterventionMessage('fillHandleDirection', MIGRATION_URL),
   ),
-  fillOperation: migrateDeepProperty(
-    ['cellSelection', 'handle', 'setFillValue'],
-    migrateOptionalValue(),
-    getManualInterventionMessage('fillOperation', MIGRATION_URL),
-  ),
+  fillOperation: removeProperty(getManualInterventionMessage('fillOperation', MIGRATION_URL)),
 
   suppressCopyRowsToClipboard: removeProperty(
     getManualInterventionMessage('suppressCopyRowsToClipboard', MIGRATION_URL),
@@ -153,11 +136,11 @@ function transformRowSelection(value: ObjectPropertyValue): t.Expression | null 
 }
 
 function transformCellSelection(value: ObjectPropertyValue): t.Expression | null {
-  // if (value.isBooleanLiteral()) {
-  //   if (value.node.value) {
-  //     return ast.expression`'cell'`;
-  //   }
-  // }
+  if (value.isBooleanLiteral()) {
+    if (value.node.value) {
+      return ast.expression`'cell'`;
+    }
+  }
 
   return null;
 }


### PR DESCRIPTION
Based on changes in https://ag-grid.atlassian.net/browse/AG-12929

Simplifies approach a little:
- `enableRangeSelection` migrated to `cellSelection`. Don't try to migrate to nested cell selection fields, complicates approach significantly and these are probably niche options and the former migration covers majority of cases.
- `rowSelection` migrated to `rowSelection` object with nested fields
  - This needed changes to `migrateDeepProperty` to handle the fact that the migration target property name is the same as the source property name
- Test cases updated